### PR TITLE
codegen: fix none options

### DIFF
--- a/pylark/lark_request.py
+++ b/pylark/lark_request.py
@@ -32,7 +32,9 @@ class MethodOption(object):
 
 
 def _new_method_option(options=None) -> MethodOption:
-    return MethodOption(options)
+    if options:
+        return MethodOption(options)
+    return MethodOption()
 
 
 @attr.s


### PR DESCRIPTION
不加这个判断，会导致走 user_access_token 的流程，进而报错。